### PR TITLE
Add max forks param to limit total number off jobs submitted

### DIFF
--- a/._wb/launcher/slurm/config.json
+++ b/._wb/launcher/slurm/config.json
@@ -22,6 +22,12 @@
             "wb_type": "integer",
             "default": "2"
         },
+        "max_forks": {
+            "help": "(optional) Maximum number of jobs of each type submitted concurrently (0 = unlimited)",
+            "wb_env": "MAX_FORKS",
+            "wb_type": "integer",
+            "default": "0"
+        },
         "tower_token": {
             "help": "Personal token used to monitor workflow status in Tower",
             "wb_type": "string",

--- a/._wb/launcher/slurm/run.sh
+++ b/._wb/launcher/slurm/run.sh
@@ -15,6 +15,13 @@ else
     PROCESS_OPT=""
 fi
 
+# If the user set the max_forks param, add it to the config
+if [[ "${MAX_FORKS}" != "0" ]]; then
+    echo "Applying the limit of process.maxForks = ${MAX_FORKS}"
+    PROCESS_OPT="""${PROCESS_OPT}
+    -process.maxForks ${MAX_FORKS}"""
+fi
+
 echo """
 
 workDir = '${WORK_DIR}'


### PR DESCRIPTION
By adding the maxForks param, we are able to limit the total number of jobs of each type which are submitted concurrently.

https://www.nextflow.io/docs/latest/process.html#maxforks